### PR TITLE
Add last updated at to policy pages

### DIFF
--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -1,0 +1,28 @@
+---
+layout: default
+
+main:
+  class: usa-grid usa-section usa-content usa-layout-docs
+---
+
+{%- assign sidenav = site.data.navigation[page.sidenav] | default: page.sidenav -%}
+
+{%- if sidenav -%}
+  <aside class="usa-layout-docs-sidenav sidenav {% if page.sticky_sidenav %}usa-sticky-sidenav{% endif %}">
+    {% include sidenav.html links=sidenav %}
+  </aside>
+{% endif -%}
+
+<div class="usa-layout-docs-main_content">
+  <header>
+    {%- if page.title -%}
+      <h1>{{ page.title }}</h1>
+
+      {%- if page.updated_at -%}
+        <small class="usa-font-lead">Last updated <time datetime="{{ page.updated_at }}">{{ page.updated_at | date_to_string: 'ordinal', 'US' }}</time>.</small>
+      {%- endif -%}
+    {%- endif -%}
+  </header>
+
+  {{ content }}
+</div>

--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -22,6 +22,10 @@ abbr[title] {
   text-decoration: none;
 }
 
+.usa-layout-docs-main_content header h1 {
+  margin-top: 0;
+}
+
 .usa-content .usa-layout-docs-main_content p {
   max-width: none;
 }

--- a/src/frequently-asked-questions.md
+++ b/src/frequently-asked-questions.md
@@ -1,5 +1,6 @@
 ---
-title: Frequently Asked Questions (FAQ)
+title: Frequently Asked Questions (FAQs)
+updated_at: 2018-03-12
 
 sticky_sidenav: false
 

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+updated_at: 2018-04-03
 ---
 
 This page will help you understand how to participate in Code.mil and comply with [OMB policy (M-16-21)](https://code.gov/#/policy-guide/docs/overview/introduction) for [open source code](https://code.gov/#/policy-guide/policy/open-source). Get started by answering a few questions, and then we can direct you to the right information or start a more in depth conversation.

--- a/src/how-to-open-source.md
+++ b/src/how-to-open-source.md
@@ -1,5 +1,6 @@
 ---
 title: How to Open Source Code
+updated_at: 2018-02-14
 
 subnav:
   - text: "Step 1: Approval"


### PR DESCRIPTION
This PR resolves #225 by adding a user-visible "Last updated at…" indication to policy pages:

- /getting-started.html
- /how-to-open-source.html
- /frequently-asked-questions.html

To test this change:

1. clone this repo and install dependencies,
1. `git checkout 225-add-last-updated-at-to-policy-pages`
1. `./scripts/serve`
1. Navigate to any of the above-mentioned pages and observe a "Last updated at…" note below the page's main heading.

**Updated:** Deploy preview now available at https://deploy-preview-230--code-mil.netlify.com.

### Screenshot

<img width="1202" alt="screen shot 2018-07-10 at 10 36 52 am" src="https://user-images.githubusercontent.com/27780860/42517204-2c20692c-842d-11e8-912d-0e4cf7c04aa4.png">
