### PR TITLE
Add Netlify _redirects file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ destination: ./public
 
 include:
   - _headers
+  - _redirects
 
 host: 0.0.0.0
 

--- a/src/_redirects
+++ b/src/_redirects
@@ -1,0 +1,1 @@
+https://code-mil.netlify.com/* https://code.mil/:splat 301!


### PR DESCRIPTION
⚠️  **Merge this PR to `master` (and subsequently `production`) _after_ DNS has been updated to point to Netlify and TLS has been enabled.**

This PR adds a Netlify-specific `_redirects` file to handle redirection of the `code-mil.netlify.com` domain to `dds.mil`. See [the documentation](https://www.netlify.com/docs/redirects/) for more on this file.
