### PR TITLE
The "partners" field was malformed according to code.gov standards

### DIFF
--- a/src/_releases/github.com/USArmyResearchLab/ARL_ParaPower.json
+++ b/src/_releases/github.com/USArmyResearchLab/ARL_ParaPower.json
@@ -14,7 +14,12 @@
   "repositoryURL": "https://github.com/USArmyResearchLab/ParaPower",
   "homepageURL": "https://github.com/USArmyResearchLab/ParaPower",
   "languages": "matlab",
-  "partners": "Texas A&M University, US Naval Academy, Drexel University",
+  "partners": [
+    {
+      "name": "Texas A&M University, US Naval Academy, Drexel University",
+      "email": null
+    }
+  ],
   "permissions": {
     "licenses": [
       {


### PR DESCRIPTION
## Checklist

I have…
- [x] run the application locally (`./scripts/serve`) and verified that my changes behave as expected.
- [x] run the build process locally (`./scripts/build`) and make sure it builds correctly.
- [x] run the test suite (`./scripts/test`) and verified that all tests pass. ( *note* : the HTML link checker fails, but not sure why... the links are valid (one to code.gov, one to nextgov)
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request fixes the "partners" field for the ParaPower entry in code.json that was malformed according to code.gov standards.

## Testing

To verify the changes proposed in this pull request build the site and check the code.json file, look for ParaPower, and check the "partners" field against the code.gov standard: https://code.gov/about/compliance/inventory-code
