### PR TITLE
changed hardcoded email text to site reference [issue #235]

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 - Copyright 2018 William Entriken github.com@phor.net
 - Copyright 2018 Sean O'Shea sposhe.github@gmail.com
 - Copyright 2018 Milo van der Linden milo@codefor.nl
+- Copyright 2019 Michael Cain loud.mouth.braggart@gmail.com
 - _Add the copyright date, your name, and email address here. (PLEASE KEEP THIS LINE)_
 
 ## Note for U.S. Federal Employees

--- a/src/_data/footer.yml
+++ b/src/_data/footer.yml
@@ -55,5 +55,5 @@ contact:
   heading: Contact Us
 # Configuration for contact links for email, phone, etc...
   contact_links:
-    - text: code@dds.mil
+    - text: '{{site.email}}'
       href: mailto:{{site.email}}


### PR DESCRIPTION
In the site footer changed hardcoded email text to a variable site.email.  This is for issue #235. 
